### PR TITLE
Update: Fix repository references and rename command binary

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -16,10 +16,3 @@
 
 ### Migrations
 - 
-
-### Installation
-1. Download the `histree.tar.gz` file
-2. Extract it: `tar xzf histree.tar.gz`
-3. Run the installation: `make install`
-
-If upgrading from a previous version, check if there are any migration steps in the "Migrations" section above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.3.4
+### Bug Fixes
+- Fixed incorrect URLs in documentation and package references
+- Updated GitHub username references from 'ec' to 'fuba'
+
 ## v0.3.3
 ### Features
 - **Library Support**: Refactored core functionality into a reusable Go library
@@ -7,7 +12,7 @@
 - **Timezone Handling**: Improved handling of timestamps across different timezones
 
 ### API Changes
-- Added public library package `github.com/ec/histree-core/pkg/histree`
+- Added public library package `github.com/fuba/histree-core/pkg/histree`
 - Created stable API for database operations and formatting
 - Exported key types and constants for third-party integration
 
@@ -19,12 +24,12 @@
 ### Installation
 #### Command-line tool
 ```bash
-go install github.com/ec/histree-core/cmd/histree@latest
+go install github.com/fuba/histree-core/cmd/histree-core@latest
 ```
 
 #### Library
 ```bash
-go get github.com/ec/histree-core
+go get github.com/fuba/histree-core
 ```
 
 ## v0.2.0

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ VERSION := $(shell git describe --tags --always --dirty)
 
 all: bin/histree-core
 
-bin/histree-core: cmd/histree/*.go
-	go build -ldflags "-X main.Version=$(VERSION)" -o bin/histree-core ./cmd/histree
+bin/histree-core: cmd/histree-core/*.go
+	go build -ldflags "-X main.Version=$(VERSION)" -o bin/histree-core ./cmd/histree-core
 
 test:
 	go test -v ./...

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project was developed with the assistance of ChatGPT and GitHub Copilot.
 
 #### Go Install (recommended)
 ```sh
-go install github.com/fuba/histree-core/cmd/histree@latest
+go install github.com/fuba/histree-core/cmd/histree-core@latest
 ```
 
 #### Building from Source

--- a/cmd/histree-core/main.go
+++ b/cmd/histree-core/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ec/histree-core/pkg/histree"
+	"github.com/fuba/histree-core/pkg/histree"
 )
 
 func main() {

--- a/cmd/histree-core/main_test.go
+++ b/cmd/histree-core/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ec/histree-core/pkg/histree"
+	"github.com/fuba/histree-core/pkg/histree"
 )
 
 func setupTestDB(t *testing.T) (*histree.DB, func()) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ec/histree-core
+module github.com/fuba/histree-core
 
 go 1.18
 

--- a/pkg/histree/histree.go
+++ b/pkg/histree/histree.go
@@ -11,7 +11,7 @@ import (
 
 // Version information
 const (
-	Version = "v0.3.3"
+	Version = "v0.3.4"
 )
 
 // OutputFormat defines how history entries are formatted when displayed


### PR DESCRIPTION
- Rename command binary from 'histree' to 'histree-core' for consistency
- Fix import paths in all Go files