### PR TITLE
feat: Add update-path command to update directory paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.3.5
+### Features
+- **Path Updates**: Added new `update-path` action to update directory paths in history entries
+- Support for both exact path updates and subdirectory path updates
+- Automatic path standardization (absolute paths, cleanup)
+
 ## v0.3.4
 ### Bug Fixes
 - Fixed incorrect URLs in documentation and package references

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+- Build: `make` or `go build -ldflags "-X main.Version=$(VERSION)" -o bin/histree-core ./cmd/histree-core`
+- Test all: `make test` or `go test -v ./...`
+- Test single file: `go test -v ./cmd/histree-core/main_test.go`
+- Test specific test: `go test -v -run TestFormatVerboseWithTimezone ./cmd/histree-core`
+- Clean: `make clean`
+
+## Code Style Guidelines
+- Go version: 1.18+
+- Error handling: Use `fmt.Errorf("context: %w", err)` with error wrapping
+- Function naming: Use camelCase
+- Indentation: Tabs, not spaces
+- Return early pattern for error handling
+- Always close resources (db connections, file handles) with defer
+- Use type definitions for constants (OutputFormat)
+- Document exported functions and types
+- SQL queries should be properly indented and use parametrized queries
+- Time values should be stored in UTC, but displayed in local timezone

--- a/cmd/histree-core/main.go
+++ b/cmd/histree-core/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 func main() {
 	version := flag.Bool("version", false, "Show version information")
 	dbPath := flag.String("db", "", "Path to SQLite database (required)")
-	action := flag.String("action", "", "Action to perform: add or get")
+	action := flag.String("action", "", "Action to perform: add, get, or update-path")
 	limit := flag.Int("limit", 100, "Number of entries to retrieve")
 	currentDir := flag.String("dir", "", "Current directory for filtering entries")
 	format := flag.String("format", string(histree.FormatSimple), "Output format: json, simple, or verbose")
@@ -23,6 +24,8 @@ func main() {
 	processID := flag.Int("pid", 0, "Process ID (required for add action)")
 	verbose := flag.Bool("v", false, "Show verbose output (same as -format verbose)")
 	exitCode := flag.Int("exit", 0, "Exit code of the command")
+	oldPath := flag.String("old-path", "", "Old directory path (required for update-path action)")
+	newPath := flag.String("new-path", "", "New directory path (required for update-path action)")
 	flag.Parse()
 
 	if *version {
@@ -70,6 +73,17 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Failed to get entries: %v\n", err)
 			os.Exit(1)
 		}
+		
+	case "update-path":
+		if *oldPath == "" || *newPath == "" {
+			fmt.Fprintf(os.Stderr, "Error: both -old-path and -new-path parameters are required for update-path action\n")
+			flag.Usage()
+			os.Exit(1)
+		}
+		if err := handleUpdatePath(db, *oldPath, *newPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to update paths: %v\n", err)
+			os.Exit(1)
+		}
 
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown action: %s\n", *action)
@@ -112,4 +126,36 @@ func handleGet(db *histree.DB, limit int, currentDir string, format histree.Outp
 	}
 
 	return histree.WriteEntries(entries, os.Stdout, format)
+}
+
+func handleUpdatePath(db *histree.DB, oldPath, newPath string) error {
+	// Convert to absolute paths if they aren't already
+	if !filepath.IsAbs(oldPath) {
+		absOldPath, err := filepath.Abs(oldPath)
+		if err != nil {
+			return fmt.Errorf("failed to convert old path to absolute path: %w", err)
+		}
+		oldPath = absOldPath
+	}
+	
+	if !filepath.IsAbs(newPath) {
+		absNewPath, err := filepath.Abs(newPath)
+		if err != nil {
+			return fmt.Errorf("failed to convert new path to absolute path: %w", err)
+		}
+		newPath = absNewPath
+	}
+	
+	// Clean the paths to ensure consistent format
+	oldPath = filepath.Clean(oldPath)
+	newPath = filepath.Clean(newPath)
+	
+	// Update the paths in the database
+	count, err := db.UpdatePaths(oldPath, newPath)
+	if err != nil {
+		return err
+	}
+	
+	fmt.Printf("Updated %d entries: %s -> %s\n", count, oldPath, newPath)
+	return nil
 }


### PR DESCRIPTION
## Summary
- Add new \ action to update directory paths in history entries
- Implemented both exact path and subdirectory path updates
- Added automatic path standardization (absolute paths, path cleanup)
- Added comprehensive tests and documentation

## Test plan
- Run \?   	github.com/fuba/histree-core/pkg/histree	[no test files]
=== RUN   TestAddEntry
--- PASS: TestAddEntry (0.01s)
=== RUN   TestGetEntries
--- PASS: TestGetEntries (0.01s)
=== RUN   TestFormatVerboseWithTimezone
--- PASS: TestFormatVerboseWithTimezone (0.00s)
=== RUN   TestFormatVerboseWithSpecificTimezones
=== RUN   TestFormatVerboseWithSpecificTimezones/Timezone_UTC
=== RUN   TestFormatVerboseWithSpecificTimezones/Timezone_America/New_York
=== RUN   TestFormatVerboseWithSpecificTimezones/Timezone_Asia/Tokyo
--- PASS: TestFormatVerboseWithSpecificTimezones (0.00s)
    --- PASS: TestFormatVerboseWithSpecificTimezones/Timezone_UTC (0.00s)
    --- PASS: TestFormatVerboseWithSpecificTimezones/Timezone_America/New_York (0.00s)
    --- PASS: TestFormatVerboseWithSpecificTimezones/Timezone_Asia/Tokyo (0.00s)
=== RUN   TestUpdatePaths
--- PASS: TestUpdatePaths (0.01s)
PASS
ok  	github.com/fuba/histree-core/cmd/histree-core	0.022s to verify all tests pass
- Manually test the command with \

v0.3.5-rc.1 has been tagged for testing purposes.