### PR TITLE
chore(deps): update go-sqlite3 from v1.14.17 to v1.14.49

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/fuba/histree-core
 
-go 1.18
+go 1.21
 
-require github.com/mattn/go-sqlite3 v1.14.17
+toolchain go1.24.7
+
+require github.com/mattn/go-sqlite3 v1.14.49

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
-github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.49 h1:B8jBHC3xhxZgxztrgruTuLucebnULQnx4W7cF7SAE9w=
+github.com/mattn/go-sqlite3 v1.14.49/go.mod h1:6JTjA44L93a0QCyJef5YvlPoKXntQPjzWv5gtm9sB6w=


### PR DESCRIPTION
## Summary

- go-sqlite3 を v1.14.17 から v1.14.49 にアップデート（32バージョン差）
- go-sqlite3 は C SQLite ライブラリをラップしており、古いバージョンには上流の SQLite セキュリティパッチが含まれていない
- go directive を 1.18 から 1.21 に更新（新しい依存関係バージョンの要件）

## Test plan

- [x] `go test -v ./...` 全テスト通過
- [x] `go mod verify` チェックサム検証済み
- [x] パッチレベルの更新（1.14.x）のため、API互換性に問題なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuaeyBFn3k1khXRXjtTnj8)_